### PR TITLE
Fix multi-user encapsulation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,18 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.56.0
-          override: true
-
-      - run: rustup component add rustfmt
-      - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check --color always
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo fmt -- --check --color always
 
   test:
     name: Test on ${{ matrix.os }}
@@ -35,25 +26,9 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.56.0
-          override: true
-      - name: cargo fetch
-        uses: actions-rs/cargo@v1
-        with:
-          command: fetch
-      - name: Build tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --verbose --release --tests --all-features
-      - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose --release --all-features
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test --release --verbose --all-features
 
   no-std:
     name: Check no-std target ${{ matrix.target }}
@@ -61,23 +36,12 @@ jobs:
     strategy:
       matrix:
         target:
-          - thumbv6m-none-eabi
           - wasm32-unknown-unknown
           - wasm32-wasi
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.56.0
-          override: true
-      - run: rustup target add ${{ matrix.target }}
-      - name: cargo fetch
-        uses: actions-rs/cargo@v1
-        with:
-          command: fetch
-      - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --verbose --target ${{ matrix.target }} --all-features --lib
+          targets: ${{ matrix.target }}
+      - run: cargo build --verbose --target ${{ matrix.target }} --all-features --lib

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ irmaseal-curve = { version = "0.1.4", features = [
 byteorder = { version = "1.3", default-features = false }
 subtle = { version = "2.4.1", default-features = false }
 tiny-keccak = { version = "2.0.2", features = ["sha3", "shake"] }
+aes-gcm = { version = "0.10", optional = true }
 
 [dev-dependencies]
 rand = "0.8.4"
@@ -38,7 +39,7 @@ cgwkv = []
 kv1 = []
 waters = []
 waters_naccache = []
-mkem = []
+mkem = ["aes-gcm"]
 
 [lib]
 bench = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ subtle = { version = "2.4.1", default-features = false }
 tiny-keccak = { version = "2.0.2", features = ["sha3", "shake"] }
 aes-gcm = { version = "0.10", optional = true }
 
+[target.wasm32-unknown-unknown.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
+
 [dev-dependencies]
 rand = "0.8.4"
 criterion = "0.3.5"

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -71,7 +71,7 @@ macro_rules! bench_multi_kem {
         paste! {
             fn [<bench_multi_kem_ $scheme>](criterion: &mut Criterion) {
                 use ibe::kem::$scheme::*;
-                use ibe::kem::mkem::{MultiRecipientCiphertext, MultiRecipient};
+                use ibe::kem::mkem::{Ciphertext, MultiRecipient};
                 use ibe::{kem::IBKEM, Derive};
 
                 let mut rng = rand::thread_rng();
@@ -92,7 +92,7 @@ macro_rules! bench_multi_kem {
                                 black_box(&kids),
                                 &mut rng
                             );
-                            let _: Vec<MultiRecipientCiphertext<$struct>> = iter.collect();
+                            let _: Vec<Ciphertext<$struct>> = iter.collect();
                         })
                     },
                 );

--- a/src/kem/mkem.rs
+++ b/src/kem/mkem.rs
@@ -1,14 +1,14 @@
-//! This module contains a generic implementation shell around all three KEMs to use in a multi-recipient setting.
-//! It leverages an IBKEM + DEM to construct a KEM to hybrid an identical, randomly drawn key under
-//! different identities.
+//! This module contains a generic API around three KEMs to use in a multi-user setting.
+//! It leverages the underlying IBKEM and a DEM to construct a hybrid encryption scheme, which
+//! is used to encrypt a randomly drawn [`SharedSecret`].
 //!
 //! # Example usage:
 //!
-//! In this example we encapsulate a session key for two recipients.
+//! In this example we encapsulate a session key for two users.
 //!
 //! ```
 //! use ibe::kem::IBKEM;
-//! use ibe::kem::mkem::{MultiRecipient, MultiRecipientCiphertext};
+//! use ibe::kem::mkem::{MultiRecipient, Ciphertext};
 //! use ibe::kem::cgw_kv::CGWKV;
 //! use ibe::Derive;
 //!
@@ -24,9 +24,9 @@
 //! let usk1 = CGWKV::extract_usk(None, &sk, &derived[0], &mut rng);
 //! let usk2 = CGWKV::extract_usk(None, &sk, &derived[1], &mut rng);
 //!
-//! // Encapsulate a single session key for two recipients.
+//! // Encapsulate a single session key for two users.
 //! let (cts_iter, k) = CGWKV::multi_encaps(&pk, &derived, &mut rng);
-//! let cts: Vec<MultiRecipientCiphertext<CGWKV>> = cts_iter.collect();
+//! let cts: Vec<Ciphertext<CGWKV>> = cts_iter.collect();
 //!
 //! let k1 = CGWKV::multi_decaps(Some(&pk), &usk1, &cts[0]).unwrap();
 //! let k2 = CGWKV::multi_decaps(Some(&pk), &usk2, &cts[1]).unwrap();
@@ -52,6 +52,10 @@ use crate::kem::cgw_kv::CGWKV;
 #[cfg(feature = "kv1")]
 use crate::kem::kiltz_vahlis_one::KV1;
 
+const TAG_SIZE: usize = 16;
+const NONCE_SIZE: usize = 12;
+const KEY_SIZE: usize = 16;
+
 impl SharedSecret {
     /// Sample random shared secret.
     fn random<R: Rng + CryptoRng>(r: &mut R) -> Self {
@@ -63,17 +67,15 @@ impl SharedSecret {
 }
 
 /// A multi-recipient ciphertext.
-///
-/// This is an extension of a scheme's ciphertext.
 #[derive(Debug, Clone)]
-pub struct MultiRecipientCiphertext<K: IBKEM> {
+pub struct Ciphertext<K: IBKEM> {
     ct_asymm: K::Ct,
     ct_symm: [u8; SS_BYTES],
     tag: Tag<Aes128Gcm>,
     nonce: Nonce<Aes128Gcm>,
 }
 
-/// Iterator for multi-recipient ciphertexts.
+/// Iterator that produces multi-recipient ciphertexts.
 #[derive(Debug)]
 pub struct Ciphertexts<'a, K: IBKEM, R> {
     ss: SharedSecret,
@@ -87,23 +89,24 @@ where
     K: IBKEM,
     R: Rng + CryptoRng,
 {
-    type Item = MultiRecipientCiphertext<K>;
+    type Item = Ciphertext<K>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let id = self.ids.next()?;
 
         let (ct_asymm, kek) = <K as IBKEM>::encaps(self.pk, id, self.rng);
 
-        let aead = Aes128Gcm::new_from_slice(&kek.0[..16]).unwrap();
-        let nonce_bytes = self.rng.gen::<[u8; 12]>();
+        let aead = Aes128Gcm::new_from_slice(&kek.0[..KEY_SIZE]).unwrap();
+        let nonce_bytes = self.rng.gen::<[u8; NONCE_SIZE]>();
         let nonce = Nonce::<Aes128Gcm>::from_slice(&nonce_bytes);
 
         let mut shared_key = self.ss.0;
+
         let tag = aead
             .encrypt_in_place_detached(nonce, b"", &mut shared_key)
             .unwrap();
 
-        Some(MultiRecipientCiphertext::<K> {
+        Some(Ciphertext::<K> {
             ct_asymm,
             ct_symm: shared_key,
             nonce: *nonce,
@@ -114,7 +117,7 @@ where
 
 /// Trait that captures multi-recipient encapsulation/decapsulation.
 pub trait MultiRecipient: IBKEM {
-    /// Encapsulates a single shared secret for a multiple of counterparties.
+    /// Encapsulates a single shared secret under multiple identities.
     fn multi_encaps<'a, R: Rng + CryptoRng>(
         pk: &'a <Self as IBKEM>::Pk,
         ids: impl IntoIterator<IntoIter = Iter<'a, Self::Id>>,
@@ -132,62 +135,74 @@ pub trait MultiRecipient: IBKEM {
         (cts, ss)
     }
 
-    /// Decapsulates the single shared secret from a [`MultiRecipientCiphertext`].
+    /// Decapsulates the single shared secret from a [`Ciphertext`].
     ///
     /// # Notes
     ///
-    /// In some cases this function requires the master public key, depending on
-    /// the underlying IBKEM scheme used (e.g., CGWFO).
+    /// In some cases this function requires the master public key, depending on the underlying
+    /// IBKEM scheme used (e.g., CGWFO).
     fn multi_decaps(
         mpk: Option<&Self::Pk>,
         usk: &Self::Usk,
-        ct: &MultiRecipientCiphertext<Self>,
+        ct: &Ciphertext<Self>,
     ) -> Result<SharedSecret, Error> {
         let kek = <Self as IBKEM>::decaps(mpk, usk, &ct.ct_asymm)?;
+        let aead = Aes128Gcm::new_from_slice(&kek.0[..KEY_SIZE]).unwrap();
+        let mut shared_key = ct.ct_symm;
+        aead.decrypt_in_place_detached(&ct.nonce, b"", &mut shared_key, &ct.tag)
+            .map_err(|_e| Error)?;
 
-        let aead = Aes128Gcm::new_from_slice(&kek.0[..16]).unwrap();
-
-        let mut shared_key_encrypted = ct.ct_symm;
-        aead.decrypt_in_place_detached(&ct.nonce, b"", &mut shared_key_encrypted, &ct.tag)
-            .unwrap();
-
-        Ok(SharedSecret(shared_key_encrypted))
+        Ok(SharedSecret(shared_key))
     }
 }
 
-//macro_rules! impl_mkemct_compress {
-//    ($scheme: ident) => {
-//        impl Compress for MultiRecipientCiphertext<$scheme> {
-//            const OUTPUT_SIZE: usize = $scheme::CT_BYTES + SS_BYTES;
-//            type Output = [u8; $scheme::CT_BYTES + SS_BYTES];
-//
-//            fn to_bytes(&self) -> Self::Output {
-//                let mut res = [0u8; Self::OUTPUT_SIZE];
-//                res[..$scheme::CT_BYTES].copy_from_slice(&self.ct_i.to_bytes());
-//                res[$scheme::CT_BYTES..].copy_from_slice(&self.ss_i.0);
-//
-//                res
-//            }
-//
-//            fn from_bytes(output: &Self::Output) -> CtOption<Self> {
-//                let ct_i = <$scheme as IBKEM>::Ct::from_bytes(
-//                    &output[..$scheme::CT_BYTES].try_into().unwrap(),
-//                );
-//                let mut ss_bytes = [0u8; SS_BYTES];
-//                ss_bytes[..].copy_from_slice(&output[$scheme::CT_BYTES..]);
-//                let ss_i = SharedSecret(ss_bytes);
-//
-//                ct_i.map(|ct_i| MultiRecipientCiphertext { ct_i, ss_i })
-//            }
-//        }
-//    };
-//}
-//
-//#[cfg(feature = "cgwkv")]
-//impl_mkemct_compress!(CGWKV);
-//
-//#[cfg(feature = "cgwfo")]
-//impl_mkemct_compress!(CGWFO);
-//
-//#[cfg(feature = "kv1")]
-//impl_mkemct_compress!(KV1);
+macro_rules! impl_mkemct_compress {
+    ($scheme: ident) => {
+        impl Compress for Ciphertext<$scheme> {
+            const OUTPUT_SIZE: usize = $scheme::CT_BYTES + SS_BYTES + TAG_SIZE + NONCE_SIZE;
+            type Output = [u8; Self::OUTPUT_SIZE];
+
+            fn to_bytes(&self) -> Self::Output {
+                use arrayref::mut_array_refs;
+
+                let mut res = [0u8; Self::OUTPUT_SIZE];
+                let (ct_asymm, ct_symm, tag, nonce) =
+                    mut_array_refs![&mut res, $scheme::CT_BYTES, SS_BYTES, TAG_SIZE, NONCE_SIZE];
+
+                *ct_asymm = self.ct_asymm.to_bytes();
+                *ct_symm = self.ct_symm;
+                *tag = self.tag.into();
+                *nonce = self.nonce.into();
+
+                res
+            }
+
+            fn from_bytes(output: &Self::Output) -> CtOption<Self> {
+                use arrayref::array_refs;
+
+                let (ct_asymm, ct_symm, tag, nonce) =
+                    array_refs![&output, $scheme::CT_BYTES, SS_BYTES, TAG_SIZE, NONCE_SIZE];
+
+                let ct_asymm = <$scheme as IBKEM>::Ct::from_bytes(ct_asymm);
+                let tag = Tag::<Aes128Gcm>::from_slice(tag);
+                let nonce = Nonce::<Aes128Gcm>::from_slice(nonce);
+
+                ct_asymm.map(|ct_asymm| Ciphertext {
+                    ct_asymm,
+                    ct_symm: *ct_symm,
+                    tag: *tag,
+                    nonce: *nonce,
+                })
+            }
+        }
+    };
+}
+
+#[cfg(feature = "cgwkv")]
+impl_mkemct_compress!(CGWKV);
+
+#[cfg(feature = "cgwfo")]
+impl_mkemct_compress!(CGWFO);
+
+#[cfg(feature = "kv1")]
+impl_mkemct_compress!(KV1);

--- a/src/test_macros.rs
+++ b/src/test_macros.rs
@@ -62,7 +62,7 @@ macro_rules! test_multi_kem {
     ($name: ident) => {
         #[test]
         fn eq_multi_encaps_decaps() {
-            use crate::kem::mkem::MultiRecipient;
+            use crate::kem::mkem::{Ciphertext, MultiRecipient};
 
             let mut rng = rand::thread_rng();
 
@@ -84,7 +84,10 @@ macro_rules! test_multi_kem {
             let (cts, k) = $name::multi_encaps(&pk, &kid, &mut rng);
 
             for (i, ct) in cts.enumerate() {
-                let k_i = $name::multi_decaps(Some(&pk), &usks[i], &ct).unwrap();
+                let compressed = ct.to_bytes();
+                let decompressed = Ciphertext::<$name>::from_bytes(&compressed).unwrap();
+
+                let k_i = $name::multi_decaps(Some(&pk), &usks[i], &decompressed).unwrap();
                 assert_eq!(k, k_i);
             }
 


### PR DESCRIPTION
The previous version of multi-user encapsulation had malleable parts in the ciphertext. This was not in line with our CCA claims. The updated version uses a CCA secure KEM and DEM to construct a CCA secure multi-user KEM. It does so by generating a random session key and encrypting this session key with AES-GCM using the IBKEM shared secret as symmetric key for each user, respectively. The downsides are the extra dependency on AES, the overhead (encrypted session key, nonce and tag for each user).

Since ciphertexts produced by earlier versions are not compatible, this is a breaking change.